### PR TITLE
Change `data` parameter to `state`

### DIFF
--- a/src/Filters/Concerns/InteractsWithTableQuery.php
+++ b/src/Filters/Concerns/InteractsWithTableQuery.php
@@ -26,7 +26,7 @@ trait InteractsWithTableQuery
         $callback = $this->modifyQueryUsing;
         $this->evaluate($callback, [
             'query' => $query,
-            'data' => $data,
+            'state' => $data,
         ]);
 
         return $query;


### PR DESCRIPTION
This can help when using the `->query()` function

Example : 

```php
Tables\Filters\MultiSelectFilter::make('field')
          ->options(Model::all()->pluck('name', 'id'))
          ->query(function (Builder $query, array $state) { // <-- HERE using the $state parameter
                      // ... Some code here
                      return $query;
           }),
```